### PR TITLE
get rid of faulty prefix skipping when extracting compressed files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,12 +560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common-path"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
-
-[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,15 +1580,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3053,12 +3038,10 @@ dependencies = [
  "cfg-if",
  "chrono",
  "clap",
- "common-path",
  "dirs",
  "env_proxy",
  "fern",
  "flate2",
- "home",
  "indexmap 2.5.0",
  "indicatif",
  "libc",
@@ -3076,7 +3059,6 @@ dependencies = [
  "toml 0.8.19",
  "url",
  "winapi",
- "windows-sys 0.52.0",
  "winreg",
  "xz2",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ fern = { version = "0.7", features = ["colored"] }
 [dependencies]
 anyhow.workspace = true
 clap = { version = "4", features = ["derive"] }
-home = "0.5.9"
 indicatif = "0.17"
 reqwest = { version = "0.12", features = ["blocking", "native-tls-vendored"] }
 serde.workspace = true
@@ -45,7 +44,6 @@ sevenz-rust = "0.6.1"
 tar = "0.4"
 xz2 = "0.1.7"
 flate2 = "1"
-common-path = "1.0.0"
 cfg-if = "1"
 env_proxy = "0.4.1"
 indexmap.workspace = true
@@ -62,21 +60,3 @@ os_pipe = "1.2.1"
 winreg = "0.52.0"
 winapi = { version = "0.3", features = ["winuser", "winbase"] }
 cc = "1"
-
-[target."cfg(windows)".dependencies.windows-sys]
-features = [
-  "Win32_Foundation",
-  "Win32_Security",
-  "Win32_Storage_FileSystem",
-  "Win32_System_Diagnostics_ToolHelp",
-  "Win32_System_IO",
-  "Win32_System_Ioctl",
-  "Win32_System_JobObjects",
-  "Win32_System_Kernel",
-  "Win32_System_LibraryLoader",
-  "Win32_System_SystemInformation",
-  "Win32_System_SystemServices",
-  "Win32_System_Threading",
-  "Win32_System_WindowsProgramming",
-]
-version = "0.52.0"

--- a/src/core/install.rs
+++ b/src/core/install.rs
@@ -388,7 +388,7 @@ impl<'a> InstallConfiguration<'a> {
     /// otherwise this will copy that file into dest.
     fn extract_or_copy_to(&self, maybe_file: &Path, dest: &Path) -> Result<PathBuf> {
         if let Ok(mut extractable) = Extractable::load(maybe_file) {
-            extractable.extract_to(dest)?;
+            extractable.extract_then_skip_solo_dir(dest, Some("bin"))?;
             Ok(dest.to_path_buf())
         } else {
             utils::copy_into(maybe_file, dest)

--- a/src/utils/download.rs
+++ b/src/utils/download.rs
@@ -105,9 +105,8 @@ impl<T: Sized> DownloadOpt<T> {
 
         let maybe_indicator = self.handler.as_ref().and_then(|h| {
             (h.start)(
-                total_size,
                 format!("downloading '{}'", &self.name),
-                Style::Bytes,
+                Style::Bytes(total_size),
             )
             .ok()
         });
@@ -139,7 +138,7 @@ impl<T: Sized> DownloadOpt<T> {
                 downloaded_len = min(downloaded_len + bytes_read as u64, total_size);
                 if let Some(indicator) = &maybe_indicator {
                     // safe to unwrap, because indicator won't exist if self.handler is none
-                    (self.handler.as_ref().unwrap().update)(indicator, downloaded_len);
+                    (self.handler.as_ref().unwrap().update)(indicator, Some(downloaded_len));
                 }
                 file.write_all(&buffer[..bytes_read])?;
             } else {

--- a/src/utils/extraction.rs
+++ b/src/utils/extraction.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail, Context, Result};
-use common_path::common_path_all;
 use flate2::read::GzDecoder;
 use log::info;
 use sevenz_rust::{Password, SevenZReader};

--- a/src/utils/file_system.rs
+++ b/src/utils/file_system.rs
@@ -14,9 +14,9 @@ use tempfile::NamedTempFile;
 ///
 /// Will panic if such directory cannot be determined,
 /// which could be the result of missing certain environment variable at runtime,
-/// check [`home::home_dir`] for more information.
+/// check [`dirs::home_dir`] for more information.
 pub fn home_dir() -> PathBuf {
-    home::home_dir().expect("home directory cannot be determined.")
+    dirs::home_dir().expect("home directory cannot be determined.")
 }
 
 /// Wrapper to [`std::fs::read_to_string`] but with additional error context.

--- a/src/utils/progress_bar.rs
+++ b/src/utils/progress_bar.rs
@@ -62,9 +62,9 @@ impl<'a> Progress<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct CliProgress<T: Sized> {
     /// A start/initializing function which will be called to setup progress bar.
-    pub start: fn(u64, String, Style) -> Result<T>,
+    pub start: fn(String, Style) -> Result<T>,
     /// A update function that will be called upon each step completion.
-    pub update: fn(&T, u64),
+    pub update: fn(&T, Option<u64>),
     /// A function that will be called once to terminate progress.
     pub stop: fn(&T, String),
 }
@@ -72,17 +72,21 @@ pub struct CliProgress<T: Sized> {
 #[derive(Debug, Default, Clone, Copy)]
 pub enum Style {
     /// Display the progress base on number of bytes.
-    Bytes,
-    #[default]
+    Bytes(u64),
     /// Display the progress base on position & length parameters.
-    Len,
+    Len(u64),
+    /// A spinner that spins as the progress goes, this does not require
+    /// length information.
+    #[default]
+    Spinner,
 }
 
 impl Style {
-    fn template_str(&self) -> &str {
+    fn pattern(&self) -> &str {
         match self {
-            Style::Bytes => "{bytes}/{total_bytes}",
-            Style::Len => "{pos}/{len}",
+            Style::Bytes(_) => "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})",
+            Style::Len(_) => "{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {pos}/{len} ({eta})",
+            Style::Spinner => "{spinner:.green} [{elapsed_precise}] {msg}"
         }
     }
 }
@@ -94,22 +98,35 @@ impl CliProgress<CliProgressBar> {
     /// `progress_for`: used for displaying what the progress is for.
     /// i.e.: ("downloading", "download"), ("extracting", "extraction"), etc.
     pub fn new() -> Self {
-        fn start(total: u64, msg: String, style: Style) -> Result<CliProgressBar> {
-            let pb = CliProgressBar::new(total);
-            pb.set_style(
-                ProgressStyle::with_template(
-                    &format!("{{msg}}\n{{spinner:.green}}] [{{elapsed_precise}}] [{{wide_bar:.cyan/blue}}] {} ({{eta}})", style.template_str())
-                )?
-                .with_key("eta", |state: &ProgressState, w: &mut dyn std::fmt::Write| {
-                    write!(w, "{:.1}s", state.eta().as_secs_f64()).expect("unable to display progress bar")
-                })
-                .progress_chars("#>-")
-            );
+        fn start(msg: String, style: Style) -> Result<CliProgressBar> {
+            let apply_custom_style = |pb: &CliProgressBar, pattern: &str| -> Result<()> {
+                pb.set_style(
+                    ProgressStyle::with_template(pattern)?
+                        .with_key(
+                            "eta",
+                            |state: &ProgressState, w: &mut dyn std::fmt::Write| {
+                                write!(w, "{:.1}s", state.eta().as_secs_f64())
+                                    .expect("unable to display progress bar")
+                            },
+                        )
+                        .progress_chars("#>-"),
+                );
+                Ok(())
+            };
+            let pb = match style {
+                Style::Bytes(total) | Style::Len(total) => CliProgressBar::new(total),
+                Style::Spinner => CliProgressBar::new_spinner(),
+            };
+            apply_custom_style(&pb, style.pattern())?;
             pb.set_message(msg);
             Ok(pb)
         }
-        fn update(pb: &CliProgressBar, pos: u64) {
-            pb.set_position(pos);
+        fn update(pb: &CliProgressBar, pos: Option<u64>) {
+            if let Some(p) = pos {
+                pb.set_position(p);
+            } else {
+                pb.tick();
+            }
         }
         fn stop(pb: &CliProgressBar, msg: String) {
             pb.finish_with_message(msg);

--- a/tests/extraction.rs
+++ b/tests/extraction.rs
@@ -2,7 +2,7 @@ use rim::utils::{self, Extractable};
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
-fn extract_to_temp(filename: &str) -> TempDir {
+fn extract_to_temp(filename: &str, skip_prefix: bool) -> (PathBuf, TempDir) {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("tests");
     path.push("data");
@@ -19,11 +19,18 @@ fn extract_to_temp(filename: &str) -> TempDir {
         .unwrap();
 
     let mut extractable = Extractable::load(path.as_path()).unwrap();
-    extractable
-        .extract_to(temp_dir.path())
-        .expect("failed to extract");
 
-    temp_dir
+    if skip_prefix {
+        let path = extractable
+            .extract_then_skip_solo_dir(temp_dir.path(), None::<&str>)
+            .expect("failed to extract");
+        (path, temp_dir)
+    } else {
+        extractable
+            .extract_to(temp_dir.path())
+            .expect("failed to extract");
+        (temp_dir.path().to_path_buf(), temp_dir)
+    }
 }
 
 fn assert_normal_archive(extracted: &Path) {
@@ -56,8 +63,8 @@ fn assert_extracted_with_prefixes(extracted: &Path) {
 
 #[test]
 fn extracting_simple_zip() {
-    let extracted_dir = extract_to_temp("simple_zip.zip");
-    let path = extracted_dir.path();
+    let extracted_dir = extract_to_temp("simple_zip.zip", false);
+    let path = extracted_dir.0;
 
     assert!(path.join("aaa.txt").is_file());
     assert!(path.join("bbb.txt").is_file());
@@ -66,79 +73,79 @@ fn extracting_simple_zip() {
 
 #[test]
 fn extracting_normal_zip() {
-    let temp_dir = extract_to_temp("zip_with_sub_folders.zip");
-    assert_normal_archive(temp_dir.path());
+    let temp_dir = extract_to_temp("zip_with_sub_folders.zip", false);
+    assert_normal_archive(&temp_dir.0);
 }
 
 #[test]
 fn extracting_simple_7z() {
-    let temp_dir = extract_to_temp("simple_7z.7z");
+    let temp_dir = extract_to_temp("simple_7z.7z", false);
 
-    assert!(temp_dir.path().join("aaa.txt").is_file());
-    assert!(temp_dir.path().join("bbb.txt").is_file());
-    assert!(temp_dir.path().join("ccc.txt").is_file());
+    assert!(temp_dir.0.join("aaa.txt").is_file());
+    assert!(temp_dir.0.join("bbb.txt").is_file());
+    assert!(temp_dir.0.join("ccc.txt").is_file());
 }
 
 #[test]
 fn extracting_normal_7z() {
-    let temp_dir = extract_to_temp("7z_with_sub_folders.7z");
-    assert_normal_archive(temp_dir.path());
+    let temp_dir = extract_to_temp("7z_with_sub_folders.7z", false);
+    assert_normal_archive(&temp_dir.0);
 }
 
 #[test]
 fn extracting_simple_gz() {
-    let temp_dir = extract_to_temp("simple_gz.tar.gz");
+    let temp_dir = extract_to_temp("simple_gz.tar.gz", true);
 
-    assert!(temp_dir.path().join("aaa.txt").is_file());
-    assert!(temp_dir.path().join("bbb.txt").is_file());
-    assert!(temp_dir.path().join("ccc.txt").is_file());
+    assert!(temp_dir.0.join("aaa.txt").is_file());
+    assert!(temp_dir.0.join("bbb.txt").is_file());
+    assert!(temp_dir.0.join("ccc.txt").is_file());
 }
 
 #[test]
 fn extracting_single_file_gz() {
-    let temp_dir = extract_to_temp("single_file.tar.gz");
+    let temp_dir = extract_to_temp("single_file.tar.gz", false);
 
-    println!("content: {:#?}", utils::walk_dir(temp_dir.path(), true));
-    assert!(temp_dir.path().join("aaa.txt").is_file());
+    println!("content: {:#?}", utils::walk_dir(&temp_dir.0, true));
+    assert!(temp_dir.0.join("aaa.txt").is_file());
 }
 
 #[test]
 fn extracting_normal_gz() {
-    let temp_dir = extract_to_temp("gz_with_sub_folders.tar.gz");
-    assert_normal_archive(temp_dir.path());
+    let temp_dir = extract_to_temp("gz_with_sub_folders.tar.gz", true);
+    assert_normal_archive(&temp_dir.0);
 }
 
 #[test]
 fn extracting_simple_xz() {
-    let temp_dir = extract_to_temp("simple_xz.tar.xz");
+    let temp_dir = extract_to_temp("simple_xz.tar.xz", true);
 
-    assert!(temp_dir.path().join("aaa.txt").is_file());
-    assert!(temp_dir.path().join("bbb.txt").is_file());
-    assert!(temp_dir.path().join("ccc.txt").is_file());
+    assert!(temp_dir.0.join("aaa.txt").is_file());
+    assert!(temp_dir.0.join("bbb.txt").is_file());
+    assert!(temp_dir.0.join("ccc.txt").is_file());
 }
 
 #[test]
 fn extracting_normal_xz() {
-    let temp_dir = extract_to_temp("xz_with_sub_folders.tar.xz");
-    assert_normal_archive(temp_dir.path());
+    let temp_dir = extract_to_temp("xz_with_sub_folders.tar.xz", true);
+    assert_normal_archive(&temp_dir.0);
 }
 
 #[test]
 fn extracting_xz_with_prefix() {
-    let temp_dir = extract_to_temp("xz_with_prefixes.tar.xz");
-    assert_extracted_with_prefixes(temp_dir.path());
+    let temp_dir = extract_to_temp("xz_with_prefixes.tar.xz", true);
+    assert_extracted_with_prefixes(&temp_dir.0);
 }
 
 #[test]
 fn extracting_7z_with_prefix() {
-    let temp_dir = extract_to_temp("7z_with_prefixes.7z");
+    let temp_dir = extract_to_temp("7z_with_prefixes.7z", true);
 
-    println!("content: {:#?}", utils::walk_dir(temp_dir.path(), true));
-    assert_extracted_with_prefixes(temp_dir.path());
+    println!("content: {:#?}", utils::walk_dir(&temp_dir.0, true));
+    assert_extracted_with_prefixes(&temp_dir.0);
 }
 
 #[test]
 fn extracting_zip_with_prefix() {
-    let temp_dir = extract_to_temp("zip_with_prefixes.zip");
-    assert_extracted_with_prefixes(temp_dir.path());
+    let temp_dir = extract_to_temp("zip_with_prefixes.zip", true);
+    assert_extracted_with_prefixes(&temp_dir.0);
 }


### PR DESCRIPTION
closes: #161 
closes: #146 