### PR TITLE
caching toolset manifest before update & some bug fixes

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -93,7 +93,7 @@
     "target": "target",
     "checking_manager_updates": "checking for manager updates...",
     "checking_toolkit_updates": "checking for toolkit updates...",
-    "no_available_updates": "no available updates",
+    "no_available_updates": "no available updates for toolkit '%{toolkit}'",
     "pre_update_note": "updating toolkit version to '%{target_version}' (currently '%{current_version}'), this will replace your current toolkit after installation.",
     "continue": "Continue",
     "back": "Back",
@@ -124,5 +124,7 @@
     "uninstall_toolkit_only": "Uninstall toolkit",
 
     "insecure_download": "skipping SSL certificate verification (requested by `--insecure` flag)",
-    "insecure_http_override": "using 'http' schema to skip SSL certificate verification (requested by `--insecure` flag)"
+    "insecure_http_override": "using 'http' schema to skip SSL certificate verification (requested by `--insecure` flag)",
+
+    "no_toolkit_installed": "unable to update because no toolkit was installed"
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -118,5 +118,7 @@
     "uninstall_toolkit_only": "卸载工具套件",
 
     "insecure_download": "跳过 SSL 证书验证（根据命令行选项 'insecure' 的要求）",
-    "insecure_http_override": "使用 “http” 跳过 SSL 证书验证（根据命令行选项 'insecure' 的要求）"
+    "insecure_http_override": "使用 “http” 跳过 SSL 证书验证（根据命令行选项 'insecure' 的要求）",
+
+    "no_toolkit_installed": "未安装工具套件, 无法更新"
 }

--- a/rim_gui/src-tauri/src/manager_mode.rs
+++ b/rim_gui/src-tauri/src/manager_mode.rs
@@ -174,7 +174,7 @@ fn handle_toolkit_install_click(url: String) -> Result<Vec<Component>> {
     let url_ = utils::force_parse_url(&url);
 
     // load the manifest for components information
-    let manifest = get_toolset_manifest(Some(&url_), false)?;
+    let manifest = get_toolset_manifest(Some(url_), false)?;
     let components = manifest.current_target_components(false)?;
 
     // cache the selected toolset manifest

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -43,7 +43,7 @@ pub(super) fn execute_installer(installer: &Installer) -> Result<()> {
     }
 
     let manifest_url = manifest_src.as_ref().map(|s| s.to_url()).transpose()?;
-    let mut manifest = get_toolset_manifest(manifest_url.as_ref(), *insecure)?;
+    let mut manifest = get_toolset_manifest(manifest_url, *insecure)?;
     manifest.adjust_paths()?;
 
     let component_list = manifest.current_target_components(true)?;

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -43,7 +43,7 @@ fn update_toolkit_(install_dir: &Path, insecure: bool) -> Result<()> {
     let installed = &*installed.lock().unwrap();
 
     // get possible update
-    let Some(latest_toolkit) = latest_installable_toolkit(false, insecure)? else {
+    let Some(latest_toolkit) = latest_installable_toolkit(installed, insecure)? else {
         return Ok(());
     };
     log::debug!(
@@ -63,7 +63,7 @@ fn update_toolkit_(install_dir: &Path, insecure: bool) -> Result<()> {
             must contains a valid `manifest_url`"
             )
         })?;
-    let manifest = get_toolset_manifest(Some(&manifest_url), insecure)?;
+    let manifest = get_toolset_manifest(Some(manifest_url), insecure)?;
     let new_components = manifest.current_target_components(false)?;
 
     // notify user that we will install the latest update to replace their current installation


### PR DESCRIPTION
closes: #168 

Also fixing these below issues:
1. More deadlock occurrence when detecting toolkit versions.
2. Missing translation when no toolkit update is available.
3. Falsely detects no toolkit installed when it was already installed.